### PR TITLE
Fix string and operator assertion failures

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,8 +1,6 @@
-
 import sys
 from pprint import pprint
 from tests.print_test import test_tokens
-
 
 
 if __name__ == "__main__":

--- a/tests/print_test.py
+++ b/tests/print_test.py
@@ -6,7 +6,7 @@ def test_tokens():
     lexer_wrapper = Lexer()
     lexer = lexer_wrapper.build()
 
-    test_input = '(header hi [CT:JSON, ACC:JSON])  3.14.15 "Hola" "" " " x3 123 5432 dimelo "Testing 123" '
+    test_input = '(header hi [CT:JSON, ACC:JSON])  3.14.15 == !=   > <  '
 
     lexer.input(test_input)
 

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -43,12 +43,12 @@ class TestLexer(unittest.TestCase):
     # Test operators
     def test_operators_lexer(self):
 
-        test_input = "or and == != not 32 dimelo 12345 x3"
+        test_input = "or and == != > < >= <= not 32 dimelo 12345 x3"
 
         tokens = [x for x in self.get_token_list(test_input) if x.type == "OPERATOR"]
 
-        # ==, !=
-        self.assertEqual(len(tokens), 2)
+        # ==, !=,<=, >, <, >=
+        self.assertEqual(len(tokens), 6)
 
     def test_separator_lexer(self):
 

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -1,11 +1,10 @@
 import unittest
-import re 
+import re
 from pprint import pprint
 from utils.restest_lexer import Lexer
 
 
 class TestLexer(unittest.TestCase):
-    
     def setUp(self):
         LexerWrapper = Lexer()
         self.lexer = LexerWrapper.build()
@@ -17,7 +16,7 @@ class TestLexer(unittest.TestCase):
         return None
 
     def get_token_list(self, test_input):
-        
+
         lexer = self.lexer
 
         lexer.input(test_input)
@@ -29,9 +28,8 @@ class TestLexer(unittest.TestCase):
             if not token:
                 break
             tokens.append(token)
-        
-        return tokens
 
+        return tokens
 
     def test_identifier_lexer(self):
 
@@ -42,23 +40,23 @@ class TestLexer(unittest.TestCase):
         # testing t3 x3 x123
         self.assertEqual(len(tokens), 4)
 
-    # Test operators 
+    # Test operators
     def test_operators_lexer(self):
 
         test_input = "or and == != not 32 dimelo 12345 x3"
 
         tokens = [x for x in self.get_token_list(test_input) if x.type == "OPERATOR"]
 
-        # or, and, ==, !=, not
-        self.assertEqual(len(tokens), 5)
+        # ==, !=
+        self.assertEqual(len(tokens), 2)
 
     def test_separator_lexer(self):
 
-        test_input = r'''
+        test_input = r"""
             define x3 76
             x3 == \ \n
                 5
-        '''
+        """
         tokens = [x for x in self.get_token_list(test_input) if x.type == "SEPARATOR"]
         # \ \n
         self.assertEqual(len(tokens), 2)
@@ -85,17 +83,19 @@ class TestLexer(unittest.TestCase):
 
         test_input = ' define url x3 43 567 "header url" define url '
 
-        tokens = [x for x in self.get_token_list(test_input) if x.type == "DEFINE" or x.type == "URL"]
+        tokens = [
+            x
+            for x in self.get_token_list(test_input)
+            if x.type == "DEFINE" or x.type == "URL"
+        ]
 
         self.assertEqual(len(tokens), 4)
 
     def test_tokens(self):
 
         test_input = "(header hi [CT:JSON, ACC:JSON])"
-       
+
         tokens = self.get_token_list(test_input)
 
         # all tokens except whitespace
         self.assertEqual(len(tokens), 13)
-
-

--- a/utils/restest_lexer.py
+++ b/utils/restest_lexer.py
@@ -21,6 +21,9 @@ class Lexer:
         "post": "POST",
         "put": "PUT",
         "delete": "DELETE",
+        "and": "AND",
+        "or": "OR",
+        "not": "NOT",
     }
 
     # Tokens
@@ -48,7 +51,7 @@ class Lexer:
     # REGEX
     t_ignore = " \t"
 
-    t_OPERATOR = r"(or|and|not|==|!=)"
+    t_OPERATOR = r"(==|!=|>|<|>=|<=)"
 
     t_SEPARATOR = r"\n|\\"
 
@@ -66,7 +69,7 @@ class Lexer:
 
     t_COMMA = r","
 
-    t_STRING = r'"([^"\n]|[\\"])*"'
+    t_STRING = r'"([^"\n]|(\\"))*"'
 
     @TOKEN(identifier)
     def t_IDENTIFIER(self, t):
@@ -93,4 +96,3 @@ class Lexer:
 
     def build(self, **kwargs):
         return lex.lex(module=self, **kwargs)
-        

--- a/utils/restest_lexer.py
+++ b/utils/restest_lexer.py
@@ -51,7 +51,7 @@ class Lexer:
     # REGEX
     t_ignore = " \t"
 
-    t_OPERATOR = r"(==|!=|>|<|>=|<=)"
+    t_OPERATOR = r"(==|!=|>=|<=|>|<)"
 
     t_SEPARATOR = r"\n|\\"
 


### PR DESCRIPTION
Word operators (and, or, not) are now classified as keywords.
Changed the string matching regular expression.
Added more logical operators.
Used _black_ to reformat code.